### PR TITLE
Fix regex caching in CommonService

### DIFF
--- a/src/app/shared/services/common.service.ts
+++ b/src/app/shared/services/common.service.ts
@@ -41,6 +41,7 @@ export class CommonService {
     public getAllRegex(): Observable<any> {
         if (this.firstTime) {
             this.allRegex =  this.http.get(this.api.get('getRegexBasic'), { observe: 'response' });
+            this.firstTime = false;
         }
         return this.allRegex;
     }


### PR DESCRIPTION
## Summary
- cache regex results correctly in `CommonService`

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68848052ee8c832d8f6fcf90c37a1873